### PR TITLE
Add study-mode poker assistant core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# Ignition
-Ignition poker assistant 
+# Ignition Poker Study Assistant
+
+Ignition is a study-mode poker assistant focused on Ignition Casino style NLHE cash
+games. It provides a lightweight command line coach for preflop range work and
+simple post-flop heuristics so that players can review hands away from the tables
+and stay compliant with site terms of service.
+
+## Features
+
+- Preflop range lookup for 6-max 100bb games with curated open, defend and
+  re-raise charts.
+- Post-flop heuristic engine that classifies hand strength, recognises basic
+  draws and suggests actions using a discrete action set.
+- Estimated equity versus a solid opponent range and short rationale text for
+  each recommendation to encourage understanding instead of pure memorisation.
+
+## Getting Started
+
+The assistant is implemented in pure Python. Run the CLI from the repository root:
+
+```bash
+python -m ignition.cli --stage preflop --position CO --stack 100 --hand AsKd
+```
+
+Example post-flop usage:
+
+```bash
+python -m ignition.cli \
+  --stage flop \
+  --position BTN \
+  --stack 100 \
+  --pot 9 \
+  --hand AsQs \
+  --board Td8s3s
+```
+
+### Arguments
+
+| Flag | Description |
+| ---- | ----------- |
+| `--stage` | Game stage (`preflop`, `flop`, `turn`, `river`). |
+| `--position` | Hero position (`UTG`, `HJ`, `CO`, `BTN`, `SB`, `BB`). |
+| `--stack` | Effective stack in big blinds (used for SPR and range selection). |
+| `--pot` | Pot size in big blinds (post-flop only). |
+| `--hand` | Hero hole cards, e.g. `AsKd`. |
+| `--board` | Community cards, e.g. `AhKdTs` for the flop. |
+| `--situation` | Preflop context (`open`, `vs_raise`, `vs_3bet`). |
+
+## Project Structure
+
+- `ignition/cards.py` – parsing helpers and canonical hand notation.
+- `ignition/range_engine.py` – loads curated JSON ranges and returns preflop
+  actions.
+- `ignition/postflop.py` – board texture analysis and heuristic recommendations.
+- `ignition/poker_assistant.py` – high-level facade combining both modules.
+- `ignition/data/preflop_ranges.json` – 100bb 6-max preflop ranges used by the coach.
+
+## Roadmap
+
+The current version is designed for offline study. Future improvements could
+include:
+
+- Additional stack depths (40bb, 60bb) and tournament antes.
+- Turn and river node solving distilled from full solvers to refine the
+  heuristic engine.
+- Range visualisation UI and heatmaps backed by the JSON data.
+- Opt-in hand history logging for personalised leak analysis.

--- a/ignition/__init__.py
+++ b/ignition/__init__.py
@@ -1,0 +1,5 @@
+"""Ignition poker study assistant package."""
+
+from .poker_assistant import PokerAssistant, AssistantResult
+
+__all__ = ["PokerAssistant", "AssistantResult"]

--- a/ignition/cards.py
+++ b/ignition/cards.py
@@ -1,0 +1,103 @@
+"""Utilities for working with standard playing cards used in poker."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+RANKS = "23456789TJQKA"
+SUITS = "CDHS"
+
+RANK_TO_VALUE = {rank: index + 2 for index, rank in enumerate(RANKS)}
+VALUE_TO_RANK = {value: rank for rank, value in RANK_TO_VALUE.items()}
+
+
+@dataclass(frozen=True)
+class Card:
+    """Representation of a single playing card.
+
+    The rank is stored as an uppercase single character (e.g. ``"A"``),
+    and the suit is an uppercase character (``"S"`` for spades, ``"H"`` for hearts,
+    ``"D"`` for diamonds and ``"C"`` for clubs).
+    """
+
+    rank: str
+    suit: str
+
+    def __post_init__(self) -> None:
+        if self.rank not in RANKS:
+            raise ValueError(f"Invalid rank: {self.rank!r}")
+        if self.suit not in SUITS:
+            raise ValueError(f"Invalid suit: {self.suit!r}")
+
+    @property
+    def value(self) -> int:
+        """Return the numeric value of the card rank (2 low, Ace high)."""
+
+        return RANK_TO_VALUE[self.rank]
+
+    def __str__(self) -> str:
+        return f"{self.rank}{self.suit}"
+
+
+class CardParsingError(ValueError):
+    """Raised when card parsing fails."""
+
+
+def parse_card(token: str) -> Card:
+    """Parse a single card from a two-character token."""
+
+    token = token.strip().upper()
+    if len(token) != 2:
+        raise CardParsingError(f"Invalid card token: {token!r}")
+    rank, suit = token[0], token[1]
+    try:
+        return Card(rank=rank, suit=suit)
+    except ValueError as exc:
+        raise CardParsingError(str(exc)) from exc
+
+
+def parse_cards(card_string: str) -> List[Card]:
+    """Parse a sequence of cards from a string.
+
+    The function accepts either a whitespace separated string (``"As Kd"``)
+    or a compact string without separators (``"AsKd"``).
+    """
+
+    cleaned = card_string.replace(" ", "").upper()
+    if not cleaned:
+        return []
+    if len(cleaned) % 2 != 0:
+        raise CardParsingError(
+            "Card strings must contain pairs of rank/suit characters."
+        )
+    cards = [parse_card(cleaned[i : i + 2]) for i in range(0, len(cleaned), 2)]
+
+    if len(set(cards)) != len(cards):
+        raise CardParsingError("Card string contains duplicate cards.")
+
+    return cards
+
+
+def canonicalize_hand(cards: Sequence[Card]) -> str:
+    """Return standard shorthand for a two-card hold'em hand.
+
+    ``AA`` denotes a pair of aces, ``AKs`` suited ace-king and ``AKo`` offsuit.
+    """
+
+    if len(cards) != 2:
+        raise ValueError("Exactly two cards are required for a hold'em hand.")
+
+    card1, card2 = cards
+    if card1.value == card2.value:
+        return card1.rank * 2
+
+    ranks = sorted((card1.rank, card2.rank), key=lambda r: RANK_TO_VALUE[r], reverse=True)
+    suited = card1.suit == card2.suit
+    suffix = "s" if suited else "o"
+    return f"{ranks[0]}{ranks[1]}{suffix}"
+
+
+def format_cards(cards: Iterable[Card]) -> str:
+    """Return a human readable string for a card collection."""
+
+    return " ".join(str(card) for card in cards)

--- a/ignition/cli.py
+++ b/ignition/cli.py
@@ -1,0 +1,86 @@
+"""Command line interface for the Ignition poker study assistant."""
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from .cards import CardParsingError, format_cards, parse_cards
+from .postflop import Recommendation as PostflopRecommendation
+from .postflop import recommend_postflop
+from .range_engine import PreflopRecommendation, RangeEngine
+
+
+def _parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ignition range coach CLI")
+    parser.add_argument("--stage", choices=["preflop", "flop", "turn", "river"], required=True)
+    parser.add_argument("--position", default="BTN", help="Hero position (UTG, HJ, CO, BTN, SB, BB)")
+    parser.add_argument("--stack", type=float, default=100.0, help="Effective stack in big blinds")
+    parser.add_argument("--pot", type=float, default=3.0, help="Current pot size in big blinds")
+    parser.add_argument("--hand", required=True, help="Hero hole cards, e.g. 'AsKd'")
+    parser.add_argument("--board", default="", help="Board cards, e.g. 'AhKdTs'")
+    parser.add_argument(
+        "--situation",
+        default="open",
+        choices=["open", "vs_raise", "vs_3bet"],
+        help="Preflop situation: opening, facing a raise or facing a 3-bet",
+    )
+    return parser.parse_args(argv)
+
+
+def _handle_preflop(args: argparse.Namespace) -> None:
+    engine = RangeEngine()
+    rec: PreflopRecommendation = engine.recommend(
+        position=args.position,
+        hero_hand=args.hand,
+        stack_bb=args.stack,
+        situation=args.situation,
+    )
+    print("=== Preflop Recommendation ===")
+    print(f"Position: {rec.position} | Stack configuration: {rec.stack_key} | Situation: {rec.situation}")
+    print(f"Suggested action: {rec.action.upper()}" + (f" ({rec.sizing})" if rec.sizing else ""))
+    print(f"Equity vs charted range: {rec.equity_estimate:.2f}")
+    print(rec.rationale)
+
+
+def _validate_board(stage: str, board: Sequence[object]) -> None:
+    expected = {"preflop": 0, "flop": 3, "turn": 4, "river": 5}[stage]
+    if len(board) != expected:
+        stage_name = stage.capitalize()
+        raise ValueError(f"{stage_name} requires exactly {expected} board cards (got {len(board)}).")
+
+
+def _handle_postflop(args: argparse.Namespace) -> None:
+    try:
+        hero_cards = parse_cards(args.hand)
+        board_cards = parse_cards(args.board)
+    except CardParsingError as exc:
+        raise SystemExit(f"Failed to parse cards: {exc}") from exc
+
+    _validate_board(args.stage, board_cards)
+    rec: PostflopRecommendation = recommend_postflop(
+        stage=args.stage,
+        hero=hero_cards,
+        board=board_cards,
+        pot_size=args.pot,
+        stack_size=args.stack,
+    )
+    print("=== Postflop Recommendation ===")
+    print(f"Stage: {args.stage.capitalize()} | Hero: {format_cards(hero_cards)} | Board: {format_cards(board_cards)}")
+    sizing_text = f" {rec.sizing}" if rec.sizing else ""
+    print(f"Suggested action: {rec.action.upper()}{sizing_text}")
+    print(f"Equity estimate vs top of range: {rec.equity_estimate:.2f}")
+    print(rec.rationale)
+    for key, value in rec.details.items():
+        print(f"- {key.replace('_', ' ').capitalize()}: {value}")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = _parse_arguments(argv)
+    if args.stage == "preflop":
+        _handle_preflop(args)
+    else:
+        _handle_postflop(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/ignition/data/preflop_ranges.json
+++ b/ignition/data/preflop_ranges.json
@@ -1,0 +1,140 @@
+{
+  "metadata": {
+    "game_type": "NLHE",
+    "format": "6-max",
+    "description": "Curated study ranges for 100bb stacks in Ignition cash games"
+  },
+  "ranges": {
+    "100bb": {
+      "UTG": {
+        "open": {
+          "raise": [
+            "AA", "KK", "QQ", "JJ", "TT", "99", "88",
+            "AKs", "AQs", "AJs", "KQs", "AKo", "AQo"
+          ],
+          "call": []
+        },
+        "vs_raise": {
+          "three_bet": ["AA", "KK", "QQ", "AKs", "AKo"],
+          "call": ["JJ", "TT", "AQs", "AJs", "KQs"]
+        },
+        "vs_3bet": {
+          "four_bet": ["AA", "KK", "AKs"],
+          "call": ["QQ", "JJ", "AKo", "AQs"]
+        }
+      },
+      "HJ": {
+        "open": {
+          "raise": [
+            "AA", "KK", "QQ", "JJ", "TT", "99", "88", "77",
+            "AKs", "AQs", "AJs", "ATs", "KQs", "KJs", "QJs", "JTs", "T9s",
+            "AKo", "AQo", "AJo", "KQo"
+          ],
+          "call": []
+        },
+        "vs_raise": {
+          "three_bet": ["AA", "KK", "QQ", "AKs", "AQs", "AKo"],
+          "call": ["JJ", "TT", "99", "AQo", "KQs", "AJs", "KJs", "QJs", "JTs"]
+        },
+        "vs_3bet": {
+          "four_bet": ["AA", "KK", "AKs", "AQs", "AKo"],
+          "call": ["QQ", "JJ", "TT", "AQo", "KQs"]
+        }
+      },
+      "CO": {
+        "open": {
+          "raise": [
+            "AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "66", "55",
+            "AKs", "AQs", "AJs", "ATs", "A9s", "A8s",
+            "KQs", "KJs", "KTs", "QJs", "QTs", "JTs", "T9s", "98s", "87s", "76s", "65s",
+            "AKo", "AQo", "AJo", "ATo", "KQo", "KJo", "QJo", "JTo"
+          ],
+          "call": []
+        },
+        "vs_raise": {
+          "three_bet": ["AA", "KK", "QQ", "JJ", "AKs", "AQs", "AJs", "KQs", "AKo", "AQo"],
+          "call": ["TT", "99", "88", "77", "ATs", "A9s", "KJs", "QJs", "JTs", "T9s", "AJo", "KQo"]
+        },
+        "vs_3bet": {
+          "four_bet": ["AA", "KK", "QQ", "AKs", "AQs", "AKo"],
+          "call": ["JJ", "TT", "99", "AQo", "KQs", "AJs", "ATs"]
+        }
+      },
+      "BTN": {
+        "open": {
+          "raise": [
+            "AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "66", "55", "44", "33", "22",
+            "AKs", "AQs", "AJs", "ATs", "A9s", "A8s", "A7s", "A6s", "A5s", "A4s", "A3s", "A2s",
+            "KQs", "KJs", "KTs", "K9s", "QJs", "QTs", "Q9s", "JTs", "J9s", "T9s", "T8s",
+            "98s", "97s", "87s", "86s", "76s", "75s", "65s", "54s",
+            "AKo", "AQo", "AJo", "ATo", "A9o", "KQo", "KJo", "KTo", "QJo", "QTo", "JTo", "T9o", "98o"
+          ],
+          "call": []
+        },
+        "vs_raise": {
+          "three_bet": [
+            "AA", "KK", "QQ", "JJ", "TT", "AKs", "AQs", "AJs", "ATs", "KQs", "KJs",
+            "QJs", "JTs", "T9s", "AKo", "AQo", "AJo", "KQo"
+          ],
+          "call": [
+            "99", "88", "77", "66", "55", "ATo", "A9s", "A8s", "A7s", "A6s", "A5s",
+            "KTs", "K9s", "QTs", "Q9s", "J9s", "T8s", "98s", "87s", "76s", "65s", "54s",
+            "KJo", "QJo", "JTo", "T9o", "98o"
+          ]
+        },
+        "vs_3bet": {
+          "four_bet": ["AA", "KK", "QQ", "JJ", "AKs", "AQs", "AJs", "KQs", "AKo", "AQo"],
+          "call": ["TT", "99", "88", "AJo", "ATs", "KQs", "KJs", "QJs", "JTs", "T9s", "A5s"]
+        }
+      },
+      "SB": {
+        "open": {
+          "raise": [
+            "AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "66", "55", "44", "33", "22",
+            "AKs", "AQs", "AJs", "ATs", "A9s", "A8s", "A7s", "A6s", "A5s", "A4s", "A3s", "A2s",
+            "KQs", "KJs", "KTs", "K9s", "K8s", "QJs", "QTs", "Q9s", "Q8s",
+            "JTs", "J9s", "J8s", "T9s", "T8s", "98s", "97s", "87s", "86s", "76s", "75s", "65s", "64s", "54s", "53s",
+            "AKo", "AQo", "AJo", "ATo", "A9o", "A8o", "A7o", "A6o", "A5o", "KQo", "KJo", "KTo", "K9o", "QJo", "QTo", "JTo", "T9o"
+          ],
+          "call": []
+        },
+        "vs_raise": {
+          "three_bet": ["AA", "KK", "QQ", "JJ", "TT", "AKs", "AQs", "AJs", "KQs", "AKo", "AQo"],
+          "call": ["99", "88", "77", "66", "55", "ATs", "A9s", "KJs", "QJs", "JTs", "T9s", "AJo", "KQo", "QJo", "JTo"]
+        },
+        "vs_3bet": {
+          "four_bet": ["AA", "KK", "QQ", "AKs", "AQs", "AKo"],
+          "call": ["JJ", "TT", "99", "AJs", "KQs", "AQo", "AJo", "A5s"]
+        }
+      },
+      "BB": {
+        "open": {
+          "raise": [
+            "AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "66", "55", "44", "33", "22",
+            "AKs", "AQs", "AJs", "ATs", "A9s", "A8s", "A7s", "A6s", "A5s", "A4s", "A3s", "A2s",
+            "KQs", "KJs", "KTs", "K9s", "QJs", "QTs", "Q9s", "JTs", "J9s", "T9s", "T8s",
+            "98s", "87s", "76s", "65s", "54s",
+            "AKo", "AQo", "AJo", "ATo", "A9o", "KQo", "KJo", "QJo", "JTo", "T9o"
+          ],
+          "call": []
+        },
+        "vs_raise": {
+          "three_bet": [
+            "AA", "KK", "QQ", "JJ", "TT", "99", "88", "77",
+            "AKs", "AQs", "AJs", "KQs", "KJs", "QJs", "JTs", "T9s", "98s", "87s", "76s",
+            "AKo", "AQo", "AJo", "KQo"
+          ],
+          "call": [
+            "66", "55", "44", "33", "22", "ATs", "A9s", "A8s", "A7s", "A6s", "A5s", "A4s", "A3s", "A2s",
+            "KTs", "K9s", "QTs", "Q9s", "J9s", "T8s", "97s", "86s", "75s", "65s", "54s",
+            "KJo", "QJo", "JTo", "T9o", "98o", "87o"
+          ]
+        },
+        "vs_3bet": {
+          "four_bet": ["AA", "KK", "QQ", "AKs", "AQs", "AKo"],
+          "call": ["JJ", "TT", "99", "AJs", "KQs", "AQo", "AJo", "A5s"]
+        }
+      }
+    }
+  }
+}

--- a/ignition/hand_evaluator.py
+++ b/ignition/hand_evaluator.py
@@ -1,0 +1,111 @@
+"""Hand evaluation helpers for simple Hold'em heuristics."""
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+from typing import Sequence, Tuple
+
+from .cards import Card, VALUE_TO_RANK
+
+HAND_CATEGORIES = [
+    "high_card",
+    "one_pair",
+    "two_pair",
+    "three_of_a_kind",
+    "straight",
+    "flush",
+    "full_house",
+    "four_of_a_kind",
+    "straight_flush",
+]
+HAND_CATEGORY_TO_SCORE = {name: index for index, name in enumerate(HAND_CATEGORIES)}
+
+
+class HandEvaluationError(RuntimeError):
+    """Raised when hand evaluation cannot be completed."""
+
+
+def _check_straight(ranks: Sequence[int]) -> Tuple[bool, int]:
+    """Return whether ranks form a straight and the high card if so."""
+
+    unique = sorted(set(ranks), reverse=True)
+    if len(unique) >= 5:
+        for index in range(len(unique) - 4):
+            window = unique[index : index + 5]
+            if window[0] - window[4] == 4:
+                return True, window[0]
+    # Wheel straight (A-2-3-4-5)
+    if {14, 5, 4, 3, 2}.issubset(unique):
+        return True, 5
+    return False, 0
+
+
+def _evaluate_five_cards(cards: Sequence[Card]) -> Tuple[int, Tuple[int, ...]]:
+    ranks = sorted((card.value for card in cards), reverse=True)
+    suits = [card.suit for card in cards]
+    counts = Counter(ranks)
+    is_flush = len(set(suits)) == 1
+    is_straight, straight_high = _check_straight(ranks)
+    sorted_counts = sorted(counts.items(), key=lambda item: (-item[1], -item[0]))
+
+    if is_flush and is_straight:
+        category = "straight_flush"
+        kicker = (straight_high,)
+    elif sorted_counts[0][1] == 4:
+        category = "four_of_a_kind"
+        kicker = (sorted_counts[0][0], sorted_counts[1][0])
+    elif sorted_counts[0][1] == 3 and sorted_counts[1][1] == 2:
+        category = "full_house"
+        kicker = (sorted_counts[0][0], sorted_counts[1][0])
+    elif is_flush:
+        category = "flush"
+        kicker = tuple(ranks)
+    elif is_straight:
+        category = "straight"
+        kicker = (straight_high,)
+    elif sorted_counts[0][1] == 3:
+        category = "three_of_a_kind"
+        kickers = [sorted_counts[0][0]]
+        kickers.extend(sorted((rank for rank in ranks if rank != sorted_counts[0][0]), reverse=True))
+        kicker = tuple(kickers[:3])
+    elif sorted_counts[0][1] == 2 and sorted_counts[1][1] == 2:
+        category = "two_pair"
+        pair_ranks = sorted([sorted_counts[0][0], sorted_counts[1][0]], reverse=True)
+        remaining = max(rank for rank in ranks if rank not in pair_ranks)
+        kicker = (*pair_ranks, remaining)
+    elif sorted_counts[0][1] == 2:
+        category = "one_pair"
+        pair_rank = sorted_counts[0][0]
+        kickers = [rank for rank in ranks if rank != pair_rank]
+        kicker = (pair_rank, *tuple(sorted(kickers, reverse=True)))
+    else:
+        category = "high_card"
+        kicker = tuple(ranks)
+
+    return HAND_CATEGORY_TO_SCORE[category], kicker
+
+
+def evaluate_best_hand(all_cards: Sequence[Card]) -> Tuple[str, Tuple[int, ...]]:
+    """Return the best five-card hand category and kicker tuple."""
+
+    if len(all_cards) < 5:
+        raise HandEvaluationError("At least five cards are required to evaluate a hand.")
+
+    best_score: Tuple[int, Tuple[int, ...]] | None = None
+    best_category = "high_card"
+    for combo in combinations(all_cards, 5):
+        score = _evaluate_five_cards(combo)
+        if best_score is None or score > best_score:
+            best_score = score
+            best_category = HAND_CATEGORIES[score[0]]
+
+    if best_score is None:
+        raise HandEvaluationError("Unable to evaluate hand.")
+
+    return best_category, best_score[1]
+
+
+def rank_to_string(rank_value: int) -> str:
+    """Convert a numeric rank back to its single-character representation."""
+
+    return VALUE_TO_RANK.get(rank_value, "?")

--- a/ignition/poker_assistant.py
+++ b/ignition/poker_assistant.py
@@ -1,0 +1,107 @@
+"""High level poker assistant interface for study-mode recommendations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+from .cards import CardParsingError, parse_cards
+from .postflop import Recommendation as PostflopRecommendation
+from .postflop import recommend_postflop
+from .range_engine import PreflopRecommendation, RangeEngine
+
+
+@dataclass
+class AssistantResult:
+    stage: str
+    action: str
+    sizing: Optional[str]
+    equity_estimate: float
+    rationale: str
+    metadata: Dict[str, str]
+
+
+class PokerAssistant:
+    """Facade that exposes preflop and postflop coaching recommendations."""
+
+    def __init__(self, range_path: Optional[Path] = None) -> None:
+        self._range_engine = RangeEngine(range_path)
+
+    def recommend_preflop(
+        self,
+        position: str,
+        hero_hand: str,
+        stack_bb: float,
+        situation: str = "open",
+    ) -> AssistantResult:
+        rec: PreflopRecommendation = self._range_engine.recommend(
+            position=position,
+            hero_hand=hero_hand,
+            stack_bb=stack_bb,
+            situation=situation,
+        )
+        metadata = {
+            "stack_key": rec.stack_key,
+            "position": rec.position,
+            "situation": rec.situation,
+        }
+        return AssistantResult(
+            stage="preflop",
+            action=rec.action,
+            sizing=rec.sizing,
+            equity_estimate=rec.equity_estimate,
+            rationale=rec.rationale,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _parse_board(stage: str, board_text: str) -> list:
+        board_cards = parse_cards(board_text)
+        expected = {"flop": 3, "turn": 4, "river": 5}[stage]
+        if len(board_cards) != expected:
+            raise ValueError(
+                f"{stage.capitalize()} expects {expected} community cards, got {len(board_cards)}"
+            )
+        return board_cards
+
+    def recommend_postflop(
+        self,
+        stage: str,
+        hero_hand: str,
+        board_cards: str,
+        pot_size: float,
+        stack_bb: float,
+    ) -> AssistantResult:
+        if stage not in {"flop", "turn", "river"}:
+            raise ValueError("Post-flop stage must be flop, turn or river.")
+        try:
+            hero_cards = parse_cards(hero_hand)
+        except CardParsingError as exc:
+            raise ValueError(f"Invalid hero hand: {exc}") from exc
+        if len(hero_cards) != 2:
+            raise ValueError("Hero hand must contain exactly two cards.")
+        try:
+            board = self._parse_board(stage, board_cards)
+        except CardParsingError as exc:
+            raise ValueError(f"Invalid board cards: {exc}") from exc
+        rec: PostflopRecommendation = recommend_postflop(
+            stage=stage,
+            hero=hero_cards,
+            board=board,
+            pot_size=pot_size,
+            stack_size=stack_bb,
+        )
+        metadata = {
+            "classification": rec.details.get("hand_classification", ""),
+            "best_category": rec.details.get("best_category", ""),
+            "spr": rec.details.get("spr", ""),
+            "draws": rec.details.get("draws", ""),
+        }
+        return AssistantResult(
+            stage=stage,
+            action=rec.action,
+            sizing=rec.sizing,
+            equity_estimate=rec.equity_estimate,
+            rationale=rec.rationale,
+            metadata=metadata,
+        )

--- a/ignition/postflop.py
+++ b/ignition/postflop.py
@@ -1,0 +1,202 @@
+"""Simple post-flop heuristics for a study-mode poker assistant."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+
+from .cards import Card
+from .hand_evaluator import evaluate_best_hand
+
+
+@dataclass
+class PostflopAnalysis:
+    classification: str
+    best_category: str
+    draws: Dict[str, bool]
+
+
+@dataclass
+class Recommendation:
+    stage: str
+    action: str
+    sizing: str | None
+    rationale: str
+    equity_estimate: float
+    details: Dict[str, str]
+
+
+CLASSIFICATION_EQUITY = {
+    "premium_made": 0.85,
+    "strong_made": 0.72,
+    "combo_draw": 0.62,
+    "medium_made": 0.55,
+    "draw": 0.45,
+    "weak_pair": 0.35,
+    "air": 0.2,
+}
+
+
+def _board_ranks(board: Sequence[Card]) -> List[int]:
+    return sorted((card.value for card in board), reverse=True)
+
+
+def _has_flush_draw(hero: Sequence[Card], board: Sequence[Card]) -> bool:
+    counts: Dict[str, int] = {}
+    for card in hero:
+        counts[card.suit] = counts.get(card.suit, 0) + 1
+    for card in board:
+        counts[card.suit] = counts.get(card.suit, 0) + 1
+    for suit, count in counts.items():
+        if count == 4:
+            hero_count = sum(1 for card in hero if card.suit == suit)
+            board_count = sum(1 for card in board if card.suit == suit)
+            if hero_count >= 1 and board_count >= 2:
+                return True
+    return False
+
+
+def _has_open_ended_draw(hero: Sequence[Card], board: Sequence[Card]) -> bool:
+    all_cards = hero + list(board)
+    ranks = {card.value for card in all_cards}
+    hero_ranks = {card.value for card in hero}
+    if 14 in ranks:
+        ranks.add(1)
+    if 14 in hero_ranks:
+        hero_ranks.add(1)
+    for start in range(1, 11):
+        window = {start, start + 1, start + 2, start + 3}
+        if window.issubset(ranks) and window & hero_ranks:
+            return True
+    return False
+
+
+def _is_overpair(hero: Sequence[Card], board: Sequence[Card]) -> bool:
+    if len(hero) != 2 or hero[0].value != hero[1].value:
+        return False
+    if not board:
+        return False
+    return hero[0].value > max(card.value for card in board)
+
+
+def _has_top_pair(hero: Sequence[Card], board: Sequence[Card]) -> bool:
+    if not board:
+        return False
+    top_board = max(card.value for card in board)
+    return any(card.value == top_board for card in hero)
+
+
+def _top_pair_kicker(hero: Sequence[Card], board: Sequence[Card]) -> int:
+    top_board = max(card.value for card in board)
+    kicker_values = [card.value for card in hero if card.value != top_board]
+    return max(kicker_values) if kicker_values else 0
+
+
+def _top_two(hero: Sequence[Card], board: Sequence[Card]) -> bool:
+    board_ranks = _board_ranks(board)
+    if len(board_ranks) < 2:
+        return False
+    highest = board_ranks[0]
+    second = board_ranks[1]
+    hero_values = sorted((card.value for card in hero), reverse=True)
+    return hero_values[0] >= highest and hero_values[1] >= second
+
+
+def analyze_postflop(hero: Sequence[Card], board: Sequence[Card]) -> PostflopAnalysis:
+    best_category, _ = evaluate_best_hand(list(hero) + list(board))
+    flush_draw = _has_flush_draw(hero, board)
+    straight_draw = _has_open_ended_draw(hero, board)
+    classification = "air"
+
+    if best_category in {"straight_flush", "four_of_a_kind", "full_house"}:
+        classification = "premium_made"
+    elif best_category in {"flush", "straight", "three_of_a_kind"}:
+        classification = "strong_made"
+    elif best_category == "two_pair":
+        if _top_two(hero, board):
+            classification = "strong_made"
+        else:
+            classification = "medium_made"
+    elif best_category == "one_pair":
+        if _is_overpair(hero, board):
+            classification = "medium_made"
+        elif _has_top_pair(hero, board) and _top_pair_kicker(hero, board) >= 11:
+            classification = "medium_made"
+        else:
+            classification = "weak_pair"
+
+    if classification in {"medium_made", "weak_pair", "air"} and (flush_draw or straight_draw):
+        classification = "combo_draw" if classification == "medium_made" else "draw"
+
+    draws = {"flush_draw": flush_draw, "straight_draw": straight_draw}
+    return PostflopAnalysis(classification, best_category, draws)
+
+
+def recommend_postflop(
+    stage: str,
+    hero: Sequence[Card],
+    board: Sequence[Card],
+    pot_size: float,
+    stack_size: float,
+) -> Recommendation:
+    analysis = analyze_postflop(hero, board)
+    spr = stack_size / pot_size if pot_size else float("inf")
+
+    sizing = None
+    rationale = ""
+    action = "check"
+    classification = analysis.classification
+
+    if classification == "premium_made":
+        action = "bet"
+        sizing = "100%"
+        rationale = "With a premium made hand you should build the pot aggressively."
+    elif classification == "strong_made":
+        action = "bet"
+        sizing = "66%"
+        rationale = "Strong made hands can value bet for two streets against most ranges."
+    elif classification == "combo_draw":
+        action = "bet"
+        sizing = "66%"
+        rationale = "Combination draws benefit from semi-bluffing with fold equity."
+    elif classification == "medium_made":
+        if stage == "river" or spr < 3:
+            action = "check"
+            rationale = "Control the pot with medium-strength holdings at low SPR."
+        else:
+            action = "bet"
+            sizing = "33%"
+            rationale = "Small bets with medium hands deny equity and get thin value."
+    elif classification == "draw":
+        if spr > 2:
+            action = "bet"
+            sizing = "66%"
+            rationale = "Leverage fold equity with your draw while building a pot for when you hit."
+        else:
+            action = "check"
+            rationale = "With shallow stacks take the free card rather than risking a shove."
+    elif classification == "weak_pair":
+        action = "check"
+        rationale = "Weak pairs perform best by controlling pot size and bluff-catching carefully."
+    else:
+        action = "check"
+        rationale = "Air hands should usually check-fold against aggression on this texture."
+
+    equity = CLASSIFICATION_EQUITY.get(classification, 0.25)
+    details = {
+        "hand_classification": classification,
+        "best_category": analysis.best_category,
+        "spr": f"{spr:.2f}",
+        "draws": ", ".join(
+            name for name, present in analysis.draws.items() if present
+        )
+        or "none",
+    }
+
+    return Recommendation(
+        stage=stage,
+        action=action,
+        sizing=sizing,
+        rationale=rationale,
+        equity_estimate=equity,
+        details=details,
+    )

--- a/ignition/range_engine.py
+++ b/ignition/range_engine.py
@@ -1,0 +1,151 @@
+"""Preflop range lookup for the Ignition study assistant."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Sequence
+
+from .cards import canonicalize_hand, parse_cards
+
+
+@dataclass
+class PreflopRecommendation:
+    stack_key: str
+    position: str
+    situation: str
+    action: str
+    sizing: Optional[str]
+    rationale: str
+    equity_estimate: float
+
+
+class RangeEngine:
+    """Load curated ranges and provide simple recommendations."""
+
+    def __init__(self, data_path: Optional[Path] = None) -> None:
+        if data_path is None:
+            data_path = Path(__file__).resolve().parent / "data" / "preflop_ranges.json"
+        self._data = json.loads(data_path.read_text(encoding="utf8"))
+        self._ranges: Dict[str, Dict[str, Dict[str, Dict[str, Iterable[str]]]]] = self._data["ranges"]
+
+    def available_stacks(self) -> Sequence[str]:
+        return list(self._ranges.keys())
+
+    def _stack_key(self, stack_bb: float) -> str:
+        available = []
+        for key in self.available_stacks():
+            if key.endswith("bb"):
+                try:
+                    available.append((abs(float(key[:-2]) - stack_bb), key))
+                except ValueError:
+                    continue
+        if not available:
+            raise ValueError("No stack configurations available in range data.")
+        _, nearest = min(available, key=lambda item: item[0])
+        return nearest
+
+    def recommend(
+        self,
+        position: str,
+        hero_hand: str,
+        stack_bb: float,
+        situation: str = "open",
+    ) -> PreflopRecommendation:
+        stack_key = self._stack_key(stack_bb)
+        position_key = position.upper()
+        try:
+            position_data = self._ranges[stack_key][position_key]
+        except KeyError as exc:
+            raise ValueError(f"No range data for position {position_key!r} at {stack_key}.") from exc
+
+        try:
+            situation_data = position_data[situation]
+        except KeyError as exc:
+            available = ", ".join(position_data.keys())
+            raise ValueError(
+                f"Unsupported situation {situation!r}; available: {available}."
+            ) from exc
+
+        cards = parse_cards(hero_hand)
+        if len(cards) != 2:
+            raise ValueError("Preflop recommendations require exactly two hole cards.")
+        canonical = canonicalize_hand(cards)
+
+        action = self._lookup_action(canonical, situation_data)
+        rationale = self._build_rationale(action, canonical, position_key, situation)
+        sizing = self._recommended_sizing(action, situation)
+        equity = self._equity_estimate(action)
+
+        return PreflopRecommendation(
+            stack_key=stack_key,
+            position=position_key,
+            situation=situation,
+            action=action,
+            sizing=sizing,
+            rationale=rationale,
+            equity_estimate=equity,
+        )
+
+    @staticmethod
+    def _lookup_action(hand: str, data: Dict[str, Iterable[str]]) -> str:
+        for action, combos in data.items():
+            if hand in combos:
+                return action
+        return "fold"
+
+    @staticmethod
+    def _build_rationale(action: str, hand: str, position: str, situation: str) -> str:
+        if action == "fold":
+            return f"{hand} falls outside the recommended {situation} range for {position}."
+        if situation == "open":
+            if action == "raise":
+                return f"{hand} is profitable to open-raise from {position} at this stack depth."
+            if action == "call":
+                return f"{hand} performs better as a call from {position}; avoid bloating the pot."
+            if action == "shove":
+                return f"Low SPR situations favor open-shoving premium hands like {hand}."
+        elif situation == "vs_raise":
+            if action == "three_bet":
+                return f"{hand} is strong enough to 3-bet for value or as a bluff from {position}."
+            if action == "call":
+                return f"{hand} defends the position well as a flat call versus an open raise."
+        elif situation == "vs_3bet":
+            if action == "four_bet":
+                return f"{hand} is a reliable four-bet candidate from {position} at this depth."
+            if action == "call":
+                return f"{hand} can profitably continue by calling the three-bet."  
+        return f"Follow the chart recommendation to {action} with {hand} from {position}."
+
+    @staticmethod
+    def _recommended_sizing(action: str, situation: str) -> Optional[str]:
+        if action == "fold":
+            return None
+        if situation == "open":
+            if action == "raise":
+                return "2.5bb"
+            if action == "shove":
+                return "shove"
+        if situation == "vs_raise":
+            if action == "three_bet":
+                return "3x"
+            if action == "call":
+                return "call"
+        if situation == "vs_3bet":
+            if action == "four_bet":
+                return "2.2x"
+            if action == "call":
+                return "call"
+        return None
+
+    @staticmethod
+    def _equity_estimate(action: str) -> float:
+        mapping = {
+            "fold": 0.0,
+            "raise": 0.6,
+            "call": 0.48,
+            "three_bet": 0.58,
+            "four_bet": 0.64,
+            "shove": 0.7,
+        }
+        return mapping.get(action, 0.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ignition-assistant"
+version = "0.1.0"
+description = "Study-mode poker assistant for Ignition Casino NLHE cash games"
+authors = [{ name = "Ignition Assistant" }]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "-q"

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -1,0 +1,23 @@
+import pytest
+
+from ignition.poker_assistant import PokerAssistant
+
+
+def test_assistant_preflop_facade():
+    assistant = PokerAssistant()
+    result = assistant.recommend_preflop(position="CO", hero_hand="AsKd", stack_bb=100)
+    assert result.stage == "preflop"
+    assert result.action == "raise"
+    assert result.metadata["position"] == "CO"
+
+
+def test_assistant_postflop_invalid_board_raises():
+    assistant = PokerAssistant()
+    with pytest.raises(ValueError):
+        assistant.recommend_postflop(
+            stage="flop",
+            hero_hand="AsKd",
+            board_cards="AdKh",
+            pot_size=6,
+            stack_bb=100,
+        )

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,0 +1,25 @@
+import pytest
+
+from ignition.cards import CardParsingError, canonicalize_hand, parse_cards
+
+
+def test_parse_cards_valid():
+    cards = parse_cards("AsKd")
+    assert len(cards) == 2
+    assert str(cards[0]) == "AS"
+    assert str(cards[1]) == "KD"
+
+
+def test_parse_cards_raises_on_duplicates():
+    with pytest.raises(CardParsingError):
+        parse_cards("AsAs")
+
+
+def test_canonicalize_hand_pairs_and_suited():
+    pocket = parse_cards("AhAd")
+    suited = parse_cards("AsKs")
+    offsuit = parse_cards("AdKc")
+
+    assert canonicalize_hand(pocket) == "AA"
+    assert canonicalize_hand(suited) == "AKs"
+    assert canonicalize_hand(offsuit) == "AKo"

--- a/tests/test_postflop.py
+++ b/tests/test_postflop.py
@@ -1,0 +1,19 @@
+from ignition.cards import parse_cards
+from ignition.postflop import recommend_postflop
+
+
+def test_postflop_identifies_strong_made_hand():
+    hero = parse_cards("AsKd")
+    board = parse_cards("AdKhTc")
+    rec = recommend_postflop(stage="flop", hero=hero, board=board, pot_size=9, stack_size=91)
+    assert rec.action == "bet"
+    assert rec.sizing == "66%"
+    assert rec.details["hand_classification"] == "strong_made"
+
+
+def test_postflop_detects_draw_and_prefers_betting():
+    hero = parse_cards("9s8s")
+    board = parse_cards("6s7s2d")
+    rec = recommend_postflop(stage="flop", hero=hero, board=board, pot_size=6, stack_size=94)
+    assert rec.details["hand_classification"] in {"combo_draw", "draw"}
+    assert rec.action == "bet"

--- a/tests/test_range_engine.py
+++ b/tests/test_range_engine.py
@@ -1,0 +1,22 @@
+import pytest
+
+from ignition.range_engine import RangeEngine
+
+
+def test_range_engine_recommends_raise_for_button_ak():
+    engine = RangeEngine()
+    rec = engine.recommend(position="BTN", hero_hand="AsKs", stack_bb=100, situation="open")
+    assert rec.action == "raise"
+    assert rec.sizing == "2.5bb"
+
+
+def test_range_engine_defaults_to_fold_for_outside_range():
+    engine = RangeEngine()
+    rec = engine.recommend(position="UTG", hero_hand="7c2d", stack_bb=100, situation="open")
+    assert rec.action == "fold"
+
+
+def test_unknown_situation_raises():
+    engine = RangeEngine()
+    with pytest.raises(ValueError):
+        engine.recommend(position="BTN", hero_hand="AsKs", stack_bb=100, situation="limp")


### PR DESCRIPTION
## Summary
- implement card parsing, evaluation, and heuristic recommendation modules to support study-mode decisions
- add curated 100bb preflop range data with a range engine, high-level assistant facade, and command line interface
- document usage instructions and cover the new behaviour with pytest-based unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5621ce848329a6612c87b74b651f