### PR TITLE
Add poker assistant prototype pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,114 @@
-# Ignition
-Ignition poker assistant 
+# Ignition Poker Assistant Prototype
+
+This repository contains a small end-to-end prototype that demonstrates how a
+real-time poker assistant could be built on top of screen captures.  The goal is
+not to ship a production-grade bot but to provide a clean, well-structured
+foundation that covers the three pillars outlined in the project brief:
+
+1. **Screen capture** – grab only the pixels that matter using a predefined
+   bounding box.
+2. **OCR & detection** – convert the pixels into meaningful poker data such as
+   hole cards, pot size, and stack sizes.
+3. **Decision logic** – feed the structured state into a lightweight rule engine
+   that produces an action recommendation.
+
+> ⚠️ Many poker sites forbid real-time assistance.  Use this prototype for
+> educational or post-game analysis purposes and at your own risk.
+
+## Repository layout
+
+```
+ignition/
+  capture.py       # wrappers for live capture (mss) or offline image playback
+  config.py        # dataclasses and helpers for YAML/JSON table configs
+  decision.py      # simple preflop rule engine + hand canonicalisation helpers
+  detection.py     # card template matching utilities (OpenCV)
+  ocr.py           # pytesseract wrapper with basic preprocessing
+  pipeline.py      # high-level orchestration of capture → state → decision
+  state.py         # data models for hero/opponent/table state snapshots
+configs/
+  sample_config.yaml   # example set of bounding boxes for a 6-max table
+scripts/
+  run_assistant.py     # command-line entry point for offline/live execution
+```
+
+## Getting started
+
+1. **Install system dependencies**
+
+   * Python 3.10+
+   * Tesseract OCR engine (required by `pytesseract`)
+   * Optional: a directory of 52 card template PNGs (for accurate card
+     recognition)
+
+2. **Install Python packages**
+
+   ```bash
+   pip install numpy pillow mss pytesseract opencv-python pyyaml
+   ```
+
+3. **Create or adapt a table configuration**
+
+   Copy `configs/sample_config.yaml` and tweak the bounding boxes so they match
+   your poker client.  Every coordinate is relative to the top-left corner of
+   the `table_region` capture window.
+
+4. **Collect reference screenshots (optional but recommended)**
+
+   Take a few screenshots of the table with different card combinations and chip
+   stacks.  You can then iterate quickly in offline mode without touching the
+   live client.
+
+## Running the prototype
+
+### Offline mode (recommended for development)
+
+Process one or more screenshots and print the parsed state plus the recommended
+action:
+
+```bash
+python scripts/run_assistant.py \
+  --config configs/sample_config.yaml \
+  --screenshots path/to/table_001.png path/to/table_002.png
+```
+
+If you also have a directory of pre-cropped card templates, supply it via
+`--templates` to enable template matching:
+
+```bash
+python scripts/run_assistant.py \
+  --config configs/sample_config.yaml \
+  --templates assets/card_templates \
+  --screenshots path/to/table.png
+```
+
+### Live capture mode
+
+Once the configuration and OCR/card recognition behave correctly on offline
+screenshots, you can switch to live capture.  This requires the `mss` package
+and runs the capture loop at the interval defined in the config
+(`capture_interval_ms`, 500 ms by default).
+
+```bash
+python scripts/run_assistant.py --config configs/sample_config.yaml --live
+```
+
+Press **Ctrl+C** to exit the loop.  The script prints the interpreted table
+state and the action recommendation after every frame.
+
+## Extending the prototype
+
+* Replace the rule-based engine in `ignition/decision.py` with your solver
+  output or a machine learning model.
+* Add per-site theme support by keeping multiple config files and template
+  libraries.
+* Persist captured states to disk (e.g., CSV or SQLite) for post-session
+  analysis.
+* Integrate a GUI overlay by subscribing to the `FrameInterpreter` results and
+  rendering them in a separate window.
+
+## Disclaimer
+
+This code is provided for research and educational purposes only.  Always make
+sure your usage complies with the terms of service of the poker room you play
+on.  The authors accept no responsibility for misuse.

--- a/configs/sample_config.yaml
+++ b/configs/sample_config.yaml
@@ -1,0 +1,24 @@
+# Example configuration describing the capture regions for a poker table.
+table_name: Ignition NLH
+capture:
+  table_region:
+    top: 200
+    left: 300
+    width: 800
+    height: 600
+  capture_interval_ms: 500
+regions:
+  hero_cards:
+    - {top: 650, left: 480, width: 65, height: 95}
+    - {top: 650, left: 560, width: 65, height: 95}
+  community_cards:
+    - {top: 420, left: 400, width: 65, height: 95}
+    - {top: 420, left: 480, width: 65, height: 95}
+    - {top: 420, left: 560, width: 65, height: 95}
+    - {top: 420, left: 640, width: 65, height: 95}
+    - {top: 420, left: 720, width: 65, height: 95}
+  pot: {top: 360, left: 540, width: 120, height: 40}
+  hero_stack: {top: 760, left: 520, width: 120, height: 40}
+  opponent_stacks:
+    - {top: 280, left: 120, width: 120, height: 40}
+    - {top: 220, left: 860, width: 120, height: 40}

--- a/ignition/__init__.py
+++ b/ignition/__init__.py
@@ -1,0 +1,29 @@
+"""Ignition poker assistant prototype package."""
+
+from .capture import FileCapture, ScreenCapture
+from .config import AssistantConfig, BoundingBox, CaptureConfig, RegionConfig, load_config
+from .decision import Decision, RuleBasedDecisionEngine
+from .detection import CardTemplateLibrary, TemplateMatchResult
+from .ocr import OcrEngine, OcrOptions
+from .pipeline import ExtractionResult, FrameInterpreter
+from .state import PlayerSnapshot, TableSnapshot
+
+__all__ = [
+    "AssistantConfig",
+    "BoundingBox",
+    "CaptureConfig",
+    "RegionConfig",
+    "load_config",
+    "ScreenCapture",
+    "FileCapture",
+    "CardTemplateLibrary",
+    "TemplateMatchResult",
+    "OcrEngine",
+    "OcrOptions",
+    "RuleBasedDecisionEngine",
+    "Decision",
+    "FrameInterpreter",
+    "ExtractionResult",
+    "TableSnapshot",
+    "PlayerSnapshot",
+]

--- a/ignition/capture.py
+++ b/ignition/capture.py
@@ -1,0 +1,93 @@
+"""Screen capture helpers for the Ignition poker assistant prototype."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+import time
+
+try:
+    import mss  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    mss = None  # type: ignore
+
+try:
+    from PIL import Image
+except Exception:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None  # type: ignore
+
+from .config import CaptureConfig
+
+
+def _require_pillow() -> None:
+    if Image is None:
+        raise RuntimeError("Pillow is required to run the prototype")
+
+
+def _require_numpy() -> None:
+    if np is None:
+        raise RuntimeError("NumPy is required to run the prototype")
+
+
+class ScreenCapture:
+    """Capture frames from a live poker table window using :mod:`mss`."""
+
+    def __init__(self, capture_config: CaptureConfig):
+        _require_pillow()
+        _require_numpy()
+        if mss is None:
+            raise RuntimeError(
+                "mss is not installed. Install it with `pip install mss` to enable screen capture."
+            )
+        self._capture_config = capture_config
+        self._monitor = capture_config.table_region.to_mss_monitor()
+        self._sct = mss.mss()  # type: ignore[call-arg]
+
+    def grab(self) -> np.ndarray:
+        """Capture a single frame and return it as a NumPy array."""
+
+        frame = self._sct.grab(self._monitor)
+        # mss returns BGRA data; Pillow understands raw bytes and converts to RGB
+        image = Image.frombytes("RGB", frame.size, frame.rgb)
+        return np.array(image)
+
+    def loop(self) -> Iterator[np.ndarray]:
+        """Continuously capture frames at the configured interval."""
+
+        interval_s = self._capture_config.capture_interval_ms / 1000.0
+        while True:
+            start = time.perf_counter()
+            yield self.grab()
+            elapsed = time.perf_counter() - start
+            delay = max(0.0, interval_s - elapsed)
+            if delay:
+                time.sleep(delay)
+
+
+@dataclass
+class FileCapture:
+    """Utility used for offline development with recorded screenshots."""
+
+    image_paths: Iterable[Path]
+
+    def __post_init__(self) -> None:
+        _require_pillow()
+        _require_numpy()
+        self._paths = [Path(path) for path in self.image_paths]
+        if not self._paths:
+            raise ValueError("FileCapture requires at least one image path")
+
+    def loop(self) -> Iterator[np.ndarray]:
+        for path in self._paths:
+            image = Image.open(path).convert("RGB")
+            yield np.array(image)
+
+    def grab(self) -> np.ndarray:
+        path = self._paths[0]
+        return np.array(Image.open(path).convert("RGB"))

--- a/ignition/config.py
+++ b/ignition/config.py
@@ -1,0 +1,135 @@
+"""Configuration models for the Ignition poker assistant prototype."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+
+import json
+
+
+@dataclass(frozen=True)
+class BoundingBox:
+    """Simple representation of a rectangular capture region."""
+
+    top: int
+    left: int
+    width: int
+    height: int
+
+    @property
+    def bottom(self) -> int:
+        return self.top + self.height
+
+    @property
+    def right(self) -> int:
+        return self.left + self.width
+
+    def to_mss_monitor(self) -> Dict[str, int]:
+        """Return the dictionary representation expected by :mod:`mss`."""
+
+        return {
+            "top": int(self.top),
+            "left": int(self.left),
+            "width": int(self.width),
+            "height": int(self.height),
+        }
+
+
+@dataclass
+class RegionConfig:
+    """Collection of regions that should be extracted from the poker table."""
+
+    hero_cards: List[BoundingBox] = field(default_factory=list)
+    community_cards: List[BoundingBox] = field(default_factory=list)
+    pot: Optional[BoundingBox] = None
+    hero_stack: Optional[BoundingBox] = None
+    opponent_stacks: List[BoundingBox] = field(default_factory=list)
+
+
+@dataclass
+class CaptureConfig:
+    """Options controlling screen capture frequency and bounding boxes."""
+
+    table_region: BoundingBox
+    capture_interval_ms: int = 500
+
+
+@dataclass
+class AssistantConfig:
+    """Top-level configuration for the prototype assistant."""
+
+    capture: CaptureConfig
+    regions: RegionConfig
+    table_name: str = "Unknown"
+
+    @staticmethod
+    def from_mapping(data: Mapping[str, object]) -> "AssistantConfig":
+        """Create an :class:`AssistantConfig` from a nested mapping."""
+
+        def parse_box(raw: Mapping[str, object]) -> BoundingBox:
+            return BoundingBox(
+                top=int(raw["top"]),
+                left=int(raw["left"]),
+                width=int(raw["width"]),
+                height=int(raw["height"]),
+            )
+
+        capture_mapping = data["capture"]  # type: ignore[index]
+        capture = CaptureConfig(
+            table_region=parse_box(capture_mapping["table_region"])  # type: ignore[index]
+        )
+        if "capture_interval_ms" in capture_mapping:
+            capture.capture_interval_ms = int(capture_mapping["capture_interval_ms"])  # type: ignore[index]
+
+        region_mapping = data["regions"]  # type: ignore[index]
+        regions = RegionConfig()
+
+        def parse_boxes(values: Iterable[Mapping[str, object]]) -> List[BoundingBox]:
+            return [parse_box(raw) for raw in values]
+
+        if "hero_cards" in region_mapping:
+            regions.hero_cards = parse_boxes(region_mapping["hero_cards"])  # type: ignore[index]
+        if "community_cards" in region_mapping:
+            regions.community_cards = parse_boxes(region_mapping["community_cards"])  # type: ignore[index]
+        if "opponent_stacks" in region_mapping:
+            regions.opponent_stacks = parse_boxes(region_mapping["opponent_stacks"])  # type: ignore[index]
+        if "pot" in region_mapping and region_mapping["pot"]:
+            regions.pot = parse_box(region_mapping["pot"])  # type: ignore[index]
+        if "hero_stack" in region_mapping and region_mapping["hero_stack"]:
+            regions.hero_stack = parse_box(region_mapping["hero_stack"])  # type: ignore[index]
+
+        table_name = str(data.get("table_name", "Unknown"))
+        return AssistantConfig(capture=capture, regions=regions, table_name=table_name)
+
+
+def load_config(path: Path | str) -> AssistantConfig:
+    """Load an :class:`AssistantConfig` from ``path``.
+
+    The loader supports both YAML (if :mod:`pyyaml` is installed) and JSON
+    configuration files.  YAML support is optional in order to keep the
+    prototype easy to run in restricted environments.
+    """
+
+    config_path = Path(path)
+    if not config_path.exists():
+        raise FileNotFoundError(config_path)
+
+    raw_text = config_path.read_text(encoding="utf8")
+    data: MutableMapping[str, object]
+    if config_path.suffix.lower() in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError("pyyaml is required to parse YAML configuration files")
+        data = yaml.safe_load(raw_text)
+    else:
+        data = json.loads(raw_text)
+
+    if not isinstance(data, MutableMapping):  # pragma: no cover - sanity check
+        raise TypeError("Configuration root must be a mapping")
+
+    return AssistantConfig.from_mapping(data)

--- a/ignition/decision.py
+++ b/ignition/decision.py
@@ -1,0 +1,212 @@
+"""Simple rule-based decision engine used by the prototype."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional, Set
+
+from .state import TableSnapshot
+
+
+RANK_ORDER = "AKQJT98765432"
+SUIT_ALIASES = {
+    "♠": "s",
+    "♣": "c",
+    "♥": "h",
+    "♦": "d",
+    "S": "s",
+    "C": "c",
+    "H": "h",
+    "D": "d",
+}
+POSITION_ALIASES = {
+    "UTG": "EP",
+    "UTG+1": "EP",
+    "LJ": "MP",
+    "HJ": "MP",
+    "CO": "CO",
+    "BTN": "BTN",
+    "SB": "SB",
+    "BB": "BB",
+    "MP": "MP",
+    "EP": "EP",
+}
+
+
+def _build_range(entries: Iterable[str]) -> Set[str]:
+    return {entry.upper() for entry in entries}
+
+
+DEFAULT_OPEN_RANGES: Mapping[str, Set[str]] = {
+    "EP": _build_range(["AA", "KK", "QQ", "JJ", "TT", "AKS", "AQs", "AKO"]),
+    "MP": _build_range(["AA", "KK", "QQ", "JJ", "TT", "99", "88", "AKS", "AQs", "AJs", "KQs", "AKO", "AQO"]),
+    "CO": _build_range(
+        [
+            "AA",
+            "KK",
+            "QQ",
+            "JJ",
+            "TT",
+            "99",
+            "88",
+            "77",
+            "A2S",
+            "A3S",
+            "A4S",
+            "A5S",
+            "A6S",
+            "A7S",
+            "A8S",
+            "A9S",
+            "ATS",
+            "AKO",
+            "AQO",
+            "AJO",
+            "KQO",
+            "KJS",
+            "QJS",
+            "JTS",
+        ]
+    ),
+    "BTN": _build_range(
+        [
+            "AA",
+            "KK",
+            "QQ",
+            "JJ",
+            "TT",
+            "99",
+            "88",
+            "77",
+            "66",
+            "55",
+            "44",
+            "33",
+            "22",
+            "A2S",
+            "A3S",
+            "A4S",
+            "A5S",
+            "A6S",
+            "A7S",
+            "A8S",
+            "A9S",
+            "ATS",
+            "AKO",
+            "AQO",
+            "AJO",
+            "ATO",
+            "KTO",
+            "QTO",
+            "JTO",
+            "T9S",
+            "98S",
+            "87S",
+        ]
+    ),
+    "SB": _build_range(["AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "66", "A2S", "A3S", "A4S", "A5S", "AKO", "AQO"]),
+    "BB": _build_range(["AA", "KK", "QQ", "JJ", "TT", "99", "88", "AKS", "AQS", "AKO", "AQO"]),
+}
+
+SHORT_STACK_SHOVES: Mapping[str, Set[str]] = {
+    "EP": _build_range(["AA", "KK", "QQ", "JJ", "TT", "AKS", "AKO", "AQs"]),
+    "MP": _build_range(["AA", "KK", "QQ", "JJ", "TT", "99", "88", "AKS", "AQs", "AKO", "AQo"]),
+    "CO": _build_range(["AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "AJs", "ATs", "KQs", "AKO", "AQO"]),
+    "BTN": _build_range(["AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "66", "55", "A9S", "A8S", "A5S", "AKS", "AKO", "AQO", "AJO", "KQO"]),
+    "SB": _build_range(["AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "66", "55", "A9S", "A8S", "AKO", "AQO"]),
+    "BB": _build_range(["AA", "KK", "QQ", "JJ", "TT", "99", "88", "77", "AJs", "AQO", "AKO"]),
+}
+
+
+@dataclass
+class Decision:
+    action: str
+    confidence: float
+    explanation: str
+
+
+class RuleBasedDecisionEngine:
+    """Very small rule engine built around canned preflop ranges."""
+
+    def recommend(self, table: TableSnapshot, hero_position: Optional[str]) -> Decision:
+        if len(table.hero_cards) < 2:
+            return Decision(action="No Action", confidence=0.0, explanation="Hero cards not detected yet.")
+
+        combo = canonical_hand(table.hero_cards[0], table.hero_cards[1])
+        if combo is None:
+            return Decision(action="Review", confidence=0.1, explanation="Unable to parse hero cards.")
+
+        position_key = POSITION_ALIASES.get((hero_position or "MP").upper(), "MP")
+        stack = table.hero_stack
+        if stack is not None and stack <= 12:
+            range_map = SHORT_STACK_SHOVES
+            positive_action = "Shove"
+            baseline = "Fold"
+        else:
+            range_map = DEFAULT_OPEN_RANGES
+            positive_action = "Raise"
+            baseline = "Fold"
+
+        allowed = range_map.get(position_key, set())
+        if combo in allowed:
+            explanation = (
+                f"{combo} is within the {position_key} range. Suggesting {positive_action.lower()} with stack {stack}bb"
+                if stack is not None
+                else f"{combo} in {position_key} opening range."
+            )
+            return Decision(action=positive_action, confidence=0.8, explanation=explanation)
+        explanation = (
+            f"{combo} not present in {position_key} range. Defaulting to fold." if position_key else "Hand not in range."
+        )
+        return Decision(action=baseline, confidence=0.6, explanation=explanation)
+
+
+def canonical_hand(card_a: str, card_b: str) -> Optional[str]:
+    """Return a canonical representation of a two-card poker hand."""
+
+    parsed_a = _parse_card(card_a)
+    parsed_b = _parse_card(card_b)
+    if not parsed_a or not parsed_b:
+        return None
+
+    rank_a, suit_a = parsed_a
+    rank_b, suit_b = parsed_b
+
+    idx_a = RANK_ORDER.index(rank_a)
+    idx_b = RANK_ORDER.index(rank_b)
+
+    # Ensure first rank is the higher one.
+    if idx_a > idx_b:
+        rank_a, rank_b = rank_b, rank_a
+        suit_a, suit_b = suit_b, suit_a
+        idx_a, idx_b = idx_b, idx_a
+
+    if rank_a == rank_b:
+        return f"{rank_a}{rank_b}"
+    suited = suit_a == suit_b
+    suffix = "S" if suited else "O"
+    return f"{rank_a}{rank_b}{suffix}"
+
+
+def _parse_card(card: str) -> Optional[tuple[str, str]]:
+    text = card.strip().upper()
+    if not text:
+        return None
+
+    rank = text[0]
+    rest = text[1:]
+
+    if rank == "1" and rest.startswith("0"):
+        rank = "T"
+        rest = rest[1:]
+
+    if rank not in RANK_ORDER:
+        return None
+
+    suit_char = rest[:1] if rest else ""
+    if not suit_char and len(text) >= 2:
+        suit_char = text[-1]
+
+    suit = SUIT_ALIASES.get(suit_char, suit_char.lower())
+    if suit not in {"s", "h", "d", "c"}:
+        return None
+    return rank, suit

--- a/ignition/detection.py
+++ b/ignition/detection.py
@@ -1,0 +1,91 @@
+"""Object detection helpers (card recognition and template matching)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None  # type: ignore
+
+try:
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None  # type: ignore
+
+
+@dataclass
+class TemplateMatchResult:
+    label: str
+    score: float
+
+
+class CardTemplateLibrary:
+    """Load and query template images for rank/suit recognition."""
+
+    def __init__(self, template_dir: Path, threshold: float = 0.75):
+        _require_numpy()
+        if cv2 is None:
+            raise RuntimeError(
+                "opencv-python is not installed. Install it with `pip install opencv-python` to enable template matching."
+            )
+        self._threshold = threshold
+        self._templates: Dict[str, "np.ndarray"] = {}
+        self._load_templates(template_dir)
+
+    def _load_templates(self, template_dir: Path) -> None:
+        if not template_dir.exists():
+            raise FileNotFoundError(f"Template directory not found: {template_dir}")
+        for path in template_dir.glob("*.png"):
+            label = path.stem.upper()
+            image = cv2.imread(str(path), cv2.IMREAD_GRAYSCALE)
+            if image is None:
+                continue
+            self._templates[label] = image
+        if not self._templates:
+            raise RuntimeError(f"No PNG templates found in {template_dir}")
+
+    def match_card(self, image: np.ndarray) -> Optional[TemplateMatchResult]:
+        """Return the best matching template for ``image``."""
+
+        if cv2 is None:  # pragma: no cover - handled in __init__, safeguard for linting
+            return None
+        if not self._templates:
+            return None
+
+        query = self._prepare(image)
+        best_label: Optional[str] = None
+        best_score = float("-inf")
+        for label, template in self._templates.items():
+            if query.shape[0] < template.shape[0] or query.shape[1] < template.shape[1]:
+                continue
+            result = cv2.matchTemplate(query, template, cv2.TM_CCOEFF_NORMED)
+            _, max_val, _, _ = cv2.minMaxLoc(result)
+            if max_val > best_score:
+                best_label = label
+                best_score = float(max_val)
+        if best_label and best_score >= self._threshold:
+            return TemplateMatchResult(label=best_label, score=best_score)
+        return None
+
+    @staticmethod
+    def _prepare(image: np.ndarray) -> np.ndarray:
+        if image.ndim == 3:
+            return cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        return image
+
+
+from .config import BoundingBox
+
+
+def crop_region(frame: "np.ndarray", box: BoundingBox) -> "np.ndarray":
+    """Return a NumPy array representing ``box`` cropped from ``frame``."""
+
+    return frame[box.top : box.bottom, box.left : box.right]
+
+
+def _require_numpy() -> None:
+    if np is None:
+        raise RuntimeError("NumPy is required for card template matching")

--- a/ignition/ocr.py
+++ b/ignition/ocr.py
@@ -1,0 +1,67 @@
+"""OCR utilities used to read numeric values from the poker table."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None  # type: ignore
+
+try:
+    from PIL import Image
+except Exception:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore
+
+try:
+    import pytesseract
+except Exception:  # pragma: no cover - optional dependency
+    pytesseract = None  # type: ignore
+
+
+@dataclass
+class OcrOptions:
+    """Configuration for the OCR engine."""
+
+    language: str = "eng"
+    psm: int = 7  # Treat the image as a single text line.
+    oem: int = 3  # Default OCR Engine Mode.
+    threshold: Optional[int] = 180
+
+
+class OcrEngine:
+    """Thin wrapper around :mod:`pytesseract` with basic preprocessing."""
+
+    def __init__(self, options: Optional[OcrOptions] = None):
+        _require_numpy()
+        _require_pillow()
+        if pytesseract is None:
+            raise RuntimeError(
+                "pytesseract is not installed. Install it with `pip install pytesseract` to enable OCR."
+            )
+        self._options = options or OcrOptions()
+
+    def read_text(self, image: np.ndarray) -> str:
+        """Return the text detected in ``image``."""
+
+        pil_image = Image.fromarray(image)
+        if self._options.threshold is not None:
+            pil_image = self._apply_threshold(pil_image, self._options.threshold)
+        config = f"--psm {self._options.psm} --oem {self._options.oem}"
+        return pytesseract.image_to_string(pil_image, lang=self._options.language, config=config).strip()
+
+    @staticmethod
+    def _apply_threshold(image: Image.Image, threshold: int) -> Image.Image:
+        grayscale = image.convert("L")
+        return grayscale.point(lambda p: 255 if p > threshold else 0, "1").convert("L")
+
+
+def _require_numpy() -> None:
+    if np is None:
+        raise RuntimeError("NumPy is required to run the OCR module")
+
+
+def _require_pillow() -> None:
+    if Image is None:
+        raise RuntimeError("Pillow is required to run the OCR module")

--- a/ignition/pipeline.py
+++ b/ignition/pipeline.py
@@ -1,0 +1,111 @@
+"""High level orchestration for the Ignition poker assistant prototype."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None  # type: ignore
+
+from .capture import FileCapture, ScreenCapture
+from .config import AssistantConfig, BoundingBox
+from .decision import Decision, RuleBasedDecisionEngine
+from .detection import CardTemplateLibrary, TemplateMatchResult, crop_region
+from .ocr import OcrEngine
+from .state import PlayerSnapshot, TableSnapshot
+
+
+@dataclass
+class ExtractionResult:
+    snapshot: TableSnapshot
+    decision: Decision
+
+
+class FrameInterpreter:
+    """Convert captured frames into poker decisions."""
+
+    def __init__(
+        self,
+        config: AssistantConfig,
+        *,
+        card_library: Optional[CardTemplateLibrary] = None,
+        ocr_engine: Optional[OcrEngine] = None,
+        decision_engine: Optional[RuleBasedDecisionEngine] = None,
+    ) -> None:
+        _require_numpy()
+        self._config = config
+        self._card_library = card_library
+        self._ocr = ocr_engine or OcrEngine()
+        self._decision_engine = decision_engine or RuleBasedDecisionEngine()
+
+    def process_frame(self, frame: np.ndarray, hero_position: Optional[str] = None) -> ExtractionResult:
+        snapshot = TableSnapshot(table_name=self._config.table_name)
+        snapshot.hero_cards = self._detect_cards(frame, self._config.regions.hero_cards, label_prefix="Hero")
+        snapshot.community_cards = self._detect_cards(
+            frame, self._config.regions.community_cards, label_prefix="Board"
+        )
+        if self._config.regions.pot:
+            snapshot.pot_size = self._read_amount(frame, self._config.regions.pot)
+        if self._config.regions.hero_stack:
+            snapshot.hero_stack = self._read_amount(frame, self._config.regions.hero_stack)
+        if self._config.regions.opponent_stacks:
+            snapshot.opponents = self._read_opponents(frame, self._config.regions.opponent_stacks)
+
+        if self._card_library is None:
+            snapshot.notes.append("Card templates not configured; hero cards may be placeholders.")
+
+        decision = self._decision_engine.recommend(snapshot, hero_position)
+        return ExtractionResult(snapshot=snapshot, decision=decision)
+
+    def _detect_cards(self, frame: np.ndarray, regions: Sequence[BoundingBox], *, label_prefix: str) -> list[str]:
+        cards: list[str] = []
+        for index, box in enumerate(regions, start=1):
+            crop = crop_region(frame, box)
+            label = self._match_card(crop)
+            if label is None:
+                label = f"{label_prefix}-{index:02d}"
+            cards.append(label)
+        return cards
+
+    def _match_card(self, image: np.ndarray) -> Optional[str]:
+        if self._card_library is None:
+            return None
+        result = self._card_library.match_card(image)
+        return result.label if isinstance(result, TemplateMatchResult) else None
+
+    def _read_amount(self, frame: np.ndarray, box: BoundingBox) -> Optional[float]:
+        text = self._ocr.read_text(crop_region(frame, box))
+        return _parse_amount(text)
+
+    def _read_opponents(self, frame: np.ndarray, regions: Sequence[BoundingBox]) -> list[PlayerSnapshot]:
+        opponents: list[PlayerSnapshot] = []
+        for index, box in enumerate(regions, start=1):
+            amount = self._read_amount(frame, box)
+            opponents.append(PlayerSnapshot(name=f"Villain {index}", stack=amount))
+        return opponents
+
+
+def _parse_amount(text: str) -> Optional[float]:
+    clean = text.replace("$", "").replace(",", "").strip()
+    if not clean:
+        return None
+    try:
+        return float(clean)
+    except ValueError:
+        return None
+
+
+def build_screen_capture(config: AssistantConfig) -> ScreenCapture:
+    return ScreenCapture(config.capture)
+
+
+def build_file_capture(config: AssistantConfig, paths: Iterable[str]) -> FileCapture:
+    return FileCapture(Path(path) for path in paths)
+
+
+def _require_numpy() -> None:
+    if np is None:
+        raise RuntimeError("NumPy is required to run the frame interpreter")

--- a/ignition/state.py
+++ b/ignition/state.py
@@ -1,0 +1,38 @@
+"""Data models describing the extracted poker table state."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class PlayerSnapshot:
+    """Information captured for a single player."""
+
+    name: str
+    stack: Optional[float] = None
+    position: Optional[str] = None
+
+
+@dataclass
+class TableSnapshot:
+    """Aggregated state required for the decision engine."""
+
+    table_name: str
+    hero_cards: List[str] = field(default_factory=list)
+    community_cards: List[str] = field(default_factory=list)
+    pot_size: Optional[float] = None
+    hero_stack: Optional[float] = None
+    opponents: List[PlayerSnapshot] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "table_name": self.table_name,
+            "hero_cards": self.hero_cards,
+            "community_cards": self.community_cards,
+            "pot_size": self.pot_size,
+            "hero_stack": self.hero_stack,
+            "opponents": [player.__dict__ for player in self.opponents],
+            "notes": self.notes,
+        }

--- a/scripts/run_assistant.py
+++ b/scripts/run_assistant.py
@@ -1,0 +1,107 @@
+"""Command line entry-point for the Ignition poker assistant prototype."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from PIL import Image
+
+from ignition.config import AssistantConfig, load_config
+from ignition.decision import RuleBasedDecisionEngine
+from ignition.detection import CardTemplateLibrary
+from ignition.ocr import OcrEngine
+from ignition.pipeline import FrameInterpreter
+from ignition.state import TableSnapshot
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ignition poker assistant prototype")
+    parser.add_argument("--config", required=True, help="Path to the table configuration (YAML or JSON)")
+    parser.add_argument("--templates", help="Directory containing 52 card template PNGs")
+    parser.add_argument("--hero-position", default="MP", help="Hero position (e.g. UTG, HJ, CO)")
+    parser.add_argument(
+        "--screenshots",
+        nargs="*",
+        help="Offline mode: list of PNG screenshots that will be processed sequentially",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Enable live capture via mss. Without this flag the assistant runs in offline mode.",
+    )
+    return parser.parse_args(list(argv))
+
+
+def load_templates(path: str | None) -> CardTemplateLibrary | None:
+    if not path:
+        return None
+    directory = Path(path)
+    if not directory.exists():
+        raise FileNotFoundError(directory)
+    return CardTemplateLibrary(directory)
+
+
+def load_screenshot(path: str) -> np.ndarray:
+    image = Image.open(path).convert("RGB")
+    return np.array(image)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    config = load_config(args.config)
+
+    card_library = load_templates(args.templates)
+    interpreter = FrameInterpreter(
+        config,
+        card_library=card_library,
+        ocr_engine=OcrEngine(),
+        decision_engine=RuleBasedDecisionEngine(),
+    )
+
+    if args.live:
+        return run_live_loop(interpreter, config, hero_position=args.hero_position)
+
+    if not args.screenshots:
+        print("No screenshots provided. Specify --live for real-time capture or provide PNG files.")
+        return 1
+
+    for path in args.screenshots:
+        frame = load_screenshot(path)
+        result = interpreter.process_frame(frame, hero_position=args.hero_position)
+        print_json(result.snapshot)
+        print(f"Decision: {result.decision.action} (confidence={result.decision.confidence:.2f})")
+        print(f"Explanation: {result.decision.explanation}\n")
+    return 0
+
+
+def run_live_loop(interpreter: FrameInterpreter, config: AssistantConfig, hero_position: str) -> int:
+    try:
+        from ignition.capture import ScreenCapture
+    except RuntimeError as exc:
+        print(f"Screen capture unavailable: {exc}")
+        return 1
+
+    capture = ScreenCapture(config.capture)
+    print("Starting live capture loop. Press Ctrl+C to stop.")
+    try:
+        for frame in capture.loop():
+            result = interpreter.process_frame(frame, hero_position=hero_position)
+            print_json(result.snapshot)
+            print(f"Decision: {result.decision.action} (confidence={result.decision.confidence:.2f})")
+            print(f"Explanation: {result.decision.explanation}\n")
+    except KeyboardInterrupt:
+        print("Stopping live capture loop.")
+    return 0
+
+
+def print_json(snapshot: TableSnapshot) -> None:
+    print(json.dumps(snapshot.as_dict(), indent=2))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -1,0 +1,32 @@
+"""Unit tests for the rule-based decision engine."""
+from ignition.decision import RuleBasedDecisionEngine, canonical_hand
+from ignition.state import TableSnapshot
+
+
+def test_canonical_hand_suited_and_offsuit():
+    assert canonical_hand("K♠", "8♦") == "K8O"
+    assert canonical_hand("A♠", "K♠") == "AKS"
+    assert canonical_hand("Ad", "Ac") == "AA"
+    assert canonical_hand("10h", "Js") == "JTO"
+
+
+def test_rule_engine_open_raise():
+    engine = RuleBasedDecisionEngine()
+    snapshot = TableSnapshot(table_name="Test", hero_cards=["A♠", "K♠"], hero_stack=40)
+    decision = engine.recommend(snapshot, hero_position="MP")
+    assert decision.action == "Raise"
+    assert decision.confidence > 0.5
+
+
+def test_rule_engine_short_stack_shove():
+    engine = RuleBasedDecisionEngine()
+    snapshot = TableSnapshot(table_name="Test", hero_cards=["A♠", "K♠"], hero_stack=10)
+    decision = engine.recommend(snapshot, hero_position="BTN")
+    assert decision.action == "Shove"
+
+
+def test_rule_engine_fold_unknown_hand():
+    engine = RuleBasedDecisionEngine()
+    snapshot = TableSnapshot(table_name="Test", hero_cards=["2♣", "7♦"], hero_stack=40)
+    decision = engine.recommend(snapshot, hero_position="EP")
+    assert decision.action == "Fold"


### PR DESCRIPTION
## Summary
- build a modular prototype that loads window bounding boxes, captures frames, and normalises game state
- wrap OCR and template matching helpers to extract cards, stacks, and pot information from the screen
- expose a CLI for offline or live processing plus tests covering preflop decision logic

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd56e82ce083298afc89139a074ed7